### PR TITLE
Fix: Edit page crash and heading styles

### DIFF
--- a/app/api/notes/route.ts
+++ b/app/api/notes/route.ts
@@ -28,24 +28,7 @@ export async function GET(request: Request) {
       args: [userId],
     });
     
-    const formatDate = (value: unknown): string | null => {
-      if (
-        typeof value === 'string' ||
-        typeof value === 'number' ||
-        value instanceof Date
-      ) {
-        return new Date(value).toISOString();
-      }
-      return null;
-    };
-
-    const rows = result.rows.map((r) => ({
-      ...r,
-      created_at: formatDate(r.created_at),
-      updated_at: formatDate(r.updated_at),
-    }));
-
-    return NextResponse.json(rows, { status: 200 });
+    return NextResponse.json(result.rows, { status: 200 });
   } catch (error) {
     console.error("Error fetching notes:", error);
     return NextResponse.json(

--- a/app/globals.css
+++ b/app/globals.css
@@ -119,4 +119,13 @@
   body {
     @apply bg-background text-foreground;
   }
+  h1 {
+    @apply text-2xl font-bold;
+  }
+  h2 {
+    @apply text-xl font-bold;
+  }
+  h3 {
+    @apply text-lg font-bold;
+  }
 }


### PR DESCRIPTION
This commit addresses two issues:

1.  A `RangeError: Invalid time value` crash when clicking the "Edit" button on a note. This was caused by incorrect date formatting on the server. The fix removes the server-side date formatting and relies on the client-side `date-fns` library to handle date parsing.

2.  Inconsistent heading font sizes. Base styles for `h1`, `h2`, and `h3` elements have been added to `app/globals.css` to ensure consistent styling throughout the application.